### PR TITLE
Warbler compability and minor changes for building gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg
 pom*xml
+*.gem

--- a/lib/ruby_maven.rb
+++ b/lib/ruby_maven.rb
@@ -41,7 +41,7 @@ module RubyMaven
   def self.dir
     @dir ||= File.expand_path( '../../', __FILE__ )
   end
-  
+
   def self.launch( *args )
     old_maven_home = ENV['M2_HOME']
     ENV['M2_HOME'] = Maven.home
@@ -57,10 +57,11 @@ module RubyMaven
     ENV['M2_HOME'] = old_maven_home
     FileUtils.rm_f( extensions ) unless has_extensions
   end
-    
+
   POLYGLOT_VERSION = begin
                        xml = File.read( File.join( dir, '.mvn/extensions.xml' ) )
                        xml.sub( /.*<version>/m, '' ).sub(/<\/version>.*/m, '' )
-                                        
+                     rescue Errno::ENOENT => e
+                      '0.1.11'
                      end
 end

--- a/ruby-maven.gemspec
+++ b/ruby-maven.gemspec
@@ -12,16 +12,15 @@ Gem::Specification.new do |s|
   s.email = ["m.kristian@web.de"]
 
   s.homepage = %q{https://github.com/takari/ruby-maven}
-  
-  s.license = 'EPL' 
+
+  s.license = 'EPL'
 
   s.files = `git ls-files`.split($/)
 
-  s.executables = ['rmvn']
   s.rdoc_options = ["--main", "README.md"]
 
   s.add_dependency 'ruby-maven-libs', "~> 3.3.1"
-  s.add_development_dependency 'minitest', '~> 5.3'  
+  s.add_development_dependency 'minitest', '~> 5.3'
   s.add_development_dependency 'rake', '~> 10.3'
 end
 


### PR DESCRIPTION
this PR mainly solves the problem of using ruby-maven gem with warbler gem to create a war. it seems that ruby `Dir.glob` by default ignores any directories that start with dot. as such, when warbler copies all the gem content into the war file, `.mvn` directory is ignored, which begets an exception when `POLYGLOT_VERSION` is calculated.

The solution of this PR is to ignore this exception and returns `0.1.11` by default. 

Also, this PR removes a `rmvn` executable that is no longer there.  